### PR TITLE
Collapse transactions, loop sleep

### DIFF
--- a/MarketMonitor/config.py
+++ b/MarketMonitor/config.py
@@ -43,6 +43,9 @@ conf.registerGlobalValue(MarketMonitor, 'marketsWhitelist',
     registry.SpaceSeparatedListOfStrings("", """Whitelist of markets you
     want to monitor, space separated list of short market names. Leave
     blank to include all."""))
+conf.registerGlobalValue(MarketMonitor, 'collapseThreshold',
+    registry.Integer(3, """Minimum amount of transactions upon
+    which the bot will collapse them together"""))
 
 class Formats(registry.OnlySomeStrings):
     validStrings = ('raw', 'pretty')


### PR DESCRIPTION
I've made some changes to prevent the bot from lagging behind when there's lots of updates, by collapsing updates (grouped by market-currency pair) above a certain threshold. neofutur is running this in #bitcoin-RT on freenode at the moment, if you want to see it in action.
- Add option to collapse transactions when there are many of them
  within one update. Prevents backing up of message queue, which
  would make information outdated. Threshold editable as config
  parameter.
- Add small delay of 10msec every loop iteration, to prevent 100%
  CPU usage.
- Some extra documentation/error specification
