### PR TITLE
Fallback when PGP Servers timeout

### DIFF
--- a/GPG/local/gnupg.py
+++ b/GPG/local/gnupg.py
@@ -449,6 +449,17 @@ class GPG(object):
         data.close()
         return result
 
+    def recv_key_keyservers(self, keyservers, keyid):
+        for ks in keyservers:
+            try:
+                result = recv_keys(ks, keyid)
+                if result.results[0].has_key('ok'):
+                    return result.results[0]['fingerprint']
+            except:
+               continue 
+        else:
+            raise
+
     def delete_keys(self, fingerprints, secret=False):
         which='key'
         if secret:

--- a/GPG/plugin.py
+++ b/GPG/plugin.py
@@ -247,13 +247,7 @@ class GPG(callbacks.Plugin):
         else:
             keyservers.extend(self.registryValue('keyservers').split(','))
         try:
-            for ks in keyservers:
-                result = self.gpg.recv_keys(ks, keyid)
-                if result.results[0].has_key('ok'):
-                    fingerprint = result.results[0]['fingerprint']
-                    break
-            else:
-                raise
+            result = self.gpg.recv_key_keyservers(ks, keyid)
         except:
             irc.error("Could not retrieve your key from keyserver. "
                     "Either it isn't there, or it is invalid.")
@@ -302,13 +296,7 @@ class GPG(callbacks.Plugin):
         else:
             keyservers.extend(self.registryValue('keyservers').split(','))
         try:
-            for ks in keyservers:
-                result = self.gpg.recv_keys(ks, keyid)
-                if result.results[0].has_key('ok'):
-                    fingerprint = result.results[0]['fingerprint']
-                    break
-            else:
-                raise
+            result = self.gpg.recv_key_keyservers(ks, keyid)
         except:
             irc.error("Could not retrieve your key from keyserver. "
                     "Either it isn't there, or it is invalid.")
@@ -764,13 +752,7 @@ class GPG(callbacks.Plugin):
         else:
             keyservers.extend(self.registryValue('keyservers').split(','))
         try:
-            for ks in keyservers:
-                result = self.gpg.recv_keys(ks, keyid)
-                if result.results[0].has_key('ok'):
-                    fingerprint = result.results[0]['fingerprint']
-                    break
-            else:
-                raise
+            result = self.gpg.recv_key_keyservers(keyservers, keyid)
         except:
             irc.error("Could not retrieve your key from keyserver. "
                     "Either it isn't there, or it is invalid.")
@@ -815,13 +797,7 @@ class GPG(callbacks.Plugin):
         else:
             keyservers.extend(self.registryValue('keyservers').split(','))
         try:
-            for ks in keyservers:
-                result = self.gpg.recv_keys(ks, keyid)
-                if result.results[0].has_key('ok'):
-                    fingerprint = result.results[0]['fingerprint']
-                    break
-            else:
-                raise
+            result = self.gpg.recv_key_keyservers(keyservers, keyid)
         except:
             irc.error("Could not retrieve your key from keyserver. "
                     "Either it isn't there, or it is invalid.")


### PR DESCRIPTION
When a PGP server such as pgp.mit.edu times out, an exception is raised which breaks outside of the 'for ks in keyservers' loop, so no further keyservers are attempted.

The code for this was repeated 4 times so I moved it to a function to shorten the code a bit. I included a try block inside the 'for ks in keyservers' loop so that multiple keyservers will be tried.
