### PR TITLE
Update bitcoin-otc-gpg-eauth-adium.applescript

### DIFF
--- a/GPG/helperscripts/bitcoin-otc-gpg-eauth-adium.applescript
+++ b/GPG/helperscripts/bitcoin-otc-gpg-eauth-adium.applescript
@@ -1,44 +1,38 @@
 # Thanks to TheButterZone (1TBZYXjrGjXCEN1SprpF66Jzy5uN3GiLS) for this script!
-# This works under OSX 10.6.8, Adium 1.5.*, MacGPG2 2.0.17-9
+# This works under OSX 10.6.8, Adium 1.5.*, MacGPG2 2.0.*
 # In Adium, you need to set your Freenode account options to run at least this command on connect: /join #bitcoin-otc
 # There are 2 fields you need to replace: 
-# YOURNICKGOESHERE, YOURGPGKEYIDGOESHERE
-# "delay 30" is there to allow you time to type your GPG passphrase in the prompt and hit return. Hands off keyboard & mouse after you do that.
+# YOURNICKGOESHERE, YOUR16DIGITGPGKEYIDGOESHERE
+# "delay 30" is there to allow you time to type your GPG passphrase at the prompt and hit return. Hands off keyboard & mouse after you do that.
 # Once you edit this script to your unique specs, save it as a run-only application.
 # This will not work if gribble is lagging and doesn't generate a new OTP before the event that decrypts it. Increase delay '5' (seconds) if you don't mind waiting longer.
 # If Terminal prompts because of running processes on quit, change Terminal Shell settings to Prompt before closing: *Never
 # Only run this when Adium is already logged into Freenode.
 
 tell application "Adium"
-  send the chat "#bitcoin-otc" message "/msg gribble gpg eauth YOURNICKGOESHERE"
+	send the chat "#bitcoin-otc" message "/msg gribble eauth YOURNICKGOESHERE"
 end tell
 delay 5
 tell application "Terminal"
-	do script "curl http://bitcoin-otc.com/otps/YOURGPGKEYIDGOESHERE | gpg -d | pbcopy"
+	do script "curl http://bitcoin-otc.com/otps/YOUR16DIGITGPGKEYIDGOESHERE | gpg -d | pbcopy"
 	delay 30
-	tell application "Adium"
-		activate
-		tell application "System Events"
-			keystroke "/msg gribble gpg everify "
-		end tell
-		delay 0.1
-		tell application "System Events"
-			keystroke "v" using {command down}
-		end tell
-		delay 0.1
-		tell application "System Events"
+	quit
+end tell
+tell application "Adium"
+	activate
+	tell application "System Events"
+		tell process "Adium"
+			keystroke "/msg gribble everify "
+			delay 0.1
+			key down {command}
+			delay 0.2
+			key code 9
+			key up {command}
+			delay 0.1
 			keystroke return
-		end tell
-		delay 0.1
-		tell application "System Events"
+			delay 1
 			keystroke "/msg gribble voiceme"
-		end tell
-		tell application "System Events"
 			keystroke return
 		end tell
-	end tell
-	delay 25
-	tell application "Terminal"
-		quit
 	end tell
 end tell


### PR DESCRIPTION
Major cleanup:
1) reworked "keystroke "v" using {command down}" to use the OSX key code 9 for "v", in combination with keying down {command} and then keying {command} up again; necessitated by OSX no longer pasting the pbcopy as part of the script, only by human keypressing cmd+V after the pbcopy had executed
2) consolidated tells for the everify & voiceme commands
3) stripped out apparently unnecessary 'gpg' prefix from everify and eauth gribble commands
4) had Terminal quit immediately after it was finished with GPG & eliminated the original 25 second delay before end of script that I thought it required
5) specified that the GPG key ID needed to be the 16-digit one
6) made software versions at the top less final-decimal-space-specific

I think that's it...
