### PR TITLE
Add support for min(...) and max(...) functions in OTC order book rates.

### DIFF
--- a/OTCOrderBook/plugin.py
+++ b/OTCOrderBook/plugin.py
@@ -184,8 +184,8 @@ def getIndexedPrice(irc, msg, args, state, type='price input'):
         v = args[0]
         v = re.sub(r'{mtgox(ask|bid|last|high|low|avg)}', '1', v)
         v = re.sub(r'{bitstamp(ask|bid|last|high|low|avg)}', '1', v)
-        v = re.sub(r'(min|max)', '(0)+', v)
         v = re.sub(r'{... in ...}', '1', v, 1)
+        v = re.sub(r'(min|max)', '(1)+', v)
         v = v.replace(',', '+')
         if not set(v).issubset(set('1234567890*-+./() ')) or '**' in v:
             raise ValueError, "only {mtgox(ask|bid|last|high|low|avg)}, {bitstamp(ask|bid|last|high|low|avg)}, one {... in ...}, min, max and arithmetic allowed."

--- a/OTCOrderBook/test.py
+++ b/OTCOrderBook/test.py
@@ -86,18 +86,19 @@ class OTCOrderBookTestCase(PluginTestCase):
             self.assertNotError('otcorderbook buy 2000 bitcoins @ 0.06 LRUSD')
             self.assertNotError('otcorderbook buy 3000 bitcoin at 0.07 PPUSD really nice offer!')
             self.assertNotError('otcorderbook buy 4000 btc at 10 LRUSD some text')
-            self.assertNotError('otcorderbook buy 5000 btc at max(10,20) LRUSD some text')
-            self.assertNotError('otcorderbook buy 6000 btc at min(10,20) LRUSD some text')
             self.assertNotError('view')
             self.assertRegexp('view 1', 'buy 1000')
-            self.assertRegexp('view 5', '20')
-            self.assertRegexp('view 6', '10')
             self.assertError('otcorderbook buy 5000 btc at 0.06 LRUSD mooo') # max orders
             self.assertRegexp('view', '1000.*2000')
             self.assertError('otcorderbook buy --long 5000 btc at 0.06 USD this is a long order') #not enough trust
             self.prefix = 'authedguy2!stuff@123.345.234.34'
             self.assertNotError('otcorderbook buy --long 5000 btc at 0.06 USD this is a long order') #now we have 20 total trust
             self.assertRegexp('view', '5000')
+            # Test min/max:
+            self.assertNotError('otcorderbook buy 6000 btc at max(10,20) LRUSD some text')
+            self.assertNotError('otcorderbook buy 7000 btc at min(10,20) LRUSD some text')
+            self.assertRegexp('view 6', '20')
+            self.assertRegexp('view 7', '10')
         finally:
             self.prefix = origuser
 


### PR DESCRIPTION
Example:
`buy 8 BTC at "min({bitstampask}, {mtgoxask}, 500) * 0.96" USD`
