### PR TITLE
Fix for GPG key(s) not being removed during expired registrations purge.

### DIFF
--- a/GPG/plugin.py
+++ b/GPG/plugin.py
@@ -225,7 +225,7 @@ class GPG(callbacks.Plugin):
                 if time.time() - auth['expiry'] > self.registryValue('authRequestTimeout'):
                     if auth['type'] == 'register' and not self.db.getByKey(auth['keyid']):
                         try:
-                            gpg.delete_keys(auth['fingerprint'])
+                            self.gpg.delete_keys(auth['fingerprint'])
                         except:
                             pass
                     del self.pending_auth[hostmask]


### PR DESCRIPTION
`gpg` is an instance property vs a local (unresolved reference). Was failing silently on account of the `except: pass`.
