### PR TITLE
Table title string 'amount' changed to 'No of Units'

### DIFF
--- a/OTCWebsite/vieworderbook.php
+++ b/OTCWebsite/vieworderbook.php
@@ -148,7 +148,7 @@ foreach ($eitherthingdata as $eitherthing) {
 <?php
 foreach ($validkeys as $key) $colheaders[$key] = array('linktext' => str_replace("_", " ", $key));
 $colheaders["buysell"]["linktext"] = "type";
-$colheaders["amount"]["linktext"] = "No of Units";
+$colheaders["amount"]["linktext"] = "quantity";
 $colheaders["thing"]["linktext"] = "thing";
 $colheaders["otherthing"]["linktext"] = "otherthing";
 foreach ($colheaders as $by => $colhdr) {


### PR DESCRIPTION
In some places amount refers to amount of money involved, so
amount is rename to No of Units to be explicit and easy to understand.
