### PR TITLE
Update tblb to use correct theoretical formula

### DIFF
--- a/BitcoinData/plugin.py
+++ b/BitcoinData/plugin.py
@@ -515,20 +515,13 @@ class BitcoinData(callbacks.Plugin):
     def tblb(self, irc, msg, args, interval):
         """<interval>
         
-        Calculate the expected time between blocks which take at least
-        <interval> seconds to create.
+        Calculate the expected time until a block is begun that takes at least <interval>
+        seconds to create.
         To provide the <interval> argument, a nested 'seconds' command may be helpful.
         """
-        try:
-            difficulty = float(self._diff())
-            nh = float(self._nethash3d())
-            gp = self._genprob(nh*1000, interval, difficulty)
-        except:
-            irc.error("Problem retrieving data. Try again later.")
-            return
-        sblb = (difficulty * 2**48 / 65535) / (nh * 1e9) / (1 - gp)
-        irc.reply("The expected time between blocks taking %s to generate is %s" % \
-                (utils.timeElapsed(interval), utils.timeElapsed(sblb),))
+        sblb = 600 * (math.exp(interval/600) - 1) - interval
+        irc.reply("The expected time until a block is begun that takes %s to generate is %s" % \
+                (utils.timeElapsed(interval), utils.timeElapsed(sblb)))
     tblb = wrap(tblb, ['positiveInt'])
 
 


### PR DESCRIPTION
The tblb formula is sensitive to hashrate deviation from difficulty, which causes wild inaccuracy when <interval> is large, by assuming that the deviation will last the entire time.

Also, "time between blocks which take <interval> seconds to create" is ambiguous.  Are the current and/or final block intervals included or excluded?

There is a simple closed-form theoretical [formula](http://math.stackexchange.com/questions/195560/probability-question-with-interarrival-times) for this quantity, which is analogous wait time required for a chicken that takes i seconds to cross the road, with poisson traffic.

Theoretical expected time to start of next block interval >= <interval> seconds is 600(exp(<interval>/600)-<interval>/600-1)
