### PR TITLE
Update help msg. for Ticker

### DIFF
--- a/Market/plugin.py
+++ b/Market/plugin.py
@@ -1195,7 +1195,7 @@ class Market(callbacks.Plugin):
     def ticker(self, irc, msg, args, optlist):
         """[--bid|--ask|--last|--high|--low|--avg|--vol] [--currency XXX] [--market <market>|all]
         
-        Return pretty-printed ticker. Default market is Bitfinex. 
+        Return pretty-printed ticker. Default market is Bitstamp. 
         If one of the result options is given, returns only that numeric result
         (useful for nesting in calculations).
         


### PR DESCRIPTION
Help message for Ticker function currently returns Bitfinex as the default ticker; this is incorrect and needs to be "Bitstamp".  Long-term we should allow the docstring for the default exchange for the Help functions to be defined through the config data rather than hardcoded strings...